### PR TITLE
Functionality for the done button on the keyboard

### DIFF
--- a/omniNotes/src/main/res/layout/fragment_detail.xml
+++ b/omniNotes/src/main/res/layout/fragment_detail.xml
@@ -137,6 +137,7 @@
                             android:linksClickable="false"
                             android:textAppearance="@style/Text.Big"
                             android:textColor="@color/actionbar_title_text"
+                            android:imeOptions="actionDone"
                             pixlui:typeface="RobotoSlab-Regular.ttf" />
                     </LinearLayout>
 


### PR DESCRIPTION
When the screen is in landscape mode, the keyboard pops up but the done button on the keyboard does nothing. This addition removes the keyboard just as a done button should do.