### PR TITLE
Refactoring

### DIFF
--- a/omniNotes/src/main/java/it/feio/android/omninotes/MainActivity.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/MainActivity.java
@@ -90,13 +90,6 @@ public class MainActivity extends BaseActivity implements OnDateSetListener, OnT
         new UpdaterTask(this).execute();
     }
 
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-    }
-
-
     private void initUI() {
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);

--- a/omniNotes/src/main/java/it/feio/android/omninotes/OmniNotes.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/OmniNotes.java
@@ -107,24 +107,16 @@ public class OmniNotes extends Application {
 		} else if (lang != null) {
 			// Adds language from parameter to configuration and preferences if
 			// it is not null
-			cfg.locale = new Locale(setLanguageString(lang));
+			cfg.locale = new Locale(lang.split("_")[0]);
 			prefs.edit().putString(PREF_LANG, lang).commit();
 
 		} else if (!TextUtils.isEmpty(language)) {
 			// Adds language from preferences to configuration if the string is
 			// not empty
-			cfg.locale = new Locale(setLanguageString(language));
+			cfg.locale = new Locale(language.split("_")[0]);
 		}
 
 		ctx.getResources().updateConfiguration(cfg, null);
-	}
-
-	public static String setLanguageString(String lang) {
-
-		if (lang.contains("_"))
-			return lang.split("_")[0];
-		else
-			return lang;
 	}
 
 }

--- a/omniNotes/src/main/java/it/feio/android/omninotes/OmniNotes.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/OmniNotes.java
@@ -36,12 +36,7 @@ import org.acra.sender.HttpSender.Type;
 
 import java.util.Locale;
 
-
-@ReportsCrashes(httpMethod = Method.POST, reportType = Type.FORM,
-		formUri = "http://collector.tracepot.com/3f39b042",
-		mode = ReportingInteractionMode.TOAST,
-		forceCloseDialogAfterToast = false,
-		resToastText = R.string.crash_toast)
+@ReportsCrashes(httpMethod = Method.POST, reportType = Type.FORM, formUri = "http://collector.tracepot.com/3f39b042", mode = ReportingInteractionMode.TOAST, forceCloseDialogAfterToast = false, resToastText = R.string.crash_toast)
 public class OmniNotes extends Application {
 
 	private static Context mContext;
@@ -49,7 +44,6 @@ public class OmniNotes extends Application {
 	private final static String PREF_LANG = "settings_language";
 	static SharedPreferences prefs;
 	private static RefWatcher refWatcher;
-
 
 	@Override
 	public void onCreate() {
@@ -71,7 +65,6 @@ public class OmniNotes extends Application {
 		AnalyticsHelper.init(this);
 	}
 
-
 	private void initAcra(Application application) {
 		ACRA.init(application);
 		ACRA.getErrorReporter().putCustomData("TRACEPOT_DEVELOP_MODE", isDebugBuild() ? "1" : "0");
@@ -83,7 +76,6 @@ public class OmniNotes extends Application {
 		return BuildConfig.BUILD_TYPE.equals("debug");
 	}
 
-
 	@Override
 	// Used to restore user selected locale when configuration changes
 	public void onConfigurationChanged(Configuration newConfig) {
@@ -93,7 +85,6 @@ public class OmniNotes extends Application {
 		updateLanguage(this, language);
 	}
 
-
 	public static Context getAppContext() {
 		return OmniNotes.mContext;
 	}
@@ -101,7 +92,6 @@ public class OmniNotes extends Application {
 	public static RefWatcher getRefWatcher() {
 		return OmniNotes.refWatcher;
 	}
-
 
 	/**
 	 * Updates default language with forced one
@@ -115,27 +105,26 @@ public class OmniNotes extends Application {
 			prefs.edit().putString(PREF_LANG, Locale.getDefault().toString()).commit();
 
 		} else if (lang != null) {
-			// Checks country
-			if (lang.contains("_")) {
-				cfg.locale = new Locale(lang.split("_")[0], lang.split("_")[1]);
-			} else {
-				cfg.locale = new Locale(lang);
-			}
+			// Adds language from parameter to configuration and preferences if
+			// it is not null
+			cfg.locale = new Locale(setLanguageString(lang));
 			prefs.edit().putString(PREF_LANG, lang).commit();
 
 		} else if (!TextUtils.isEmpty(language)) {
-			// Checks country
-			if (language.contains("_")) {
-				cfg.locale = new Locale(language.split("_")[0], language.split("_")[1]);
-			} else {
-				cfg.locale = new Locale(language);
-			}
+			// Adds language from preferences to configuration if the string is
+			// not empty
+			cfg.locale = new Locale(setLanguageString(language));
 		}
 
 		ctx.getResources().updateConfiguration(cfg, null);
 	}
 
+	public static String setLanguageString(String lang) {
 
-
+		if (lang.contains("_"))
+			return lang.split("_")[0];
+		else
+			return lang;
+	}
 
 }

--- a/omniNotes/src/main/java/it/feio/android/omninotes/SketchFragment.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/SketchFragment.java
@@ -92,13 +92,6 @@ public class SketchFragment extends Fragment implements OnDrawChangedListener {
         return view;
     }
 
-
-    @Override
-    public void onAttach(android.app.Activity activity) {
-        super.onAttach(activity);
-    }
-
-
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
@@ -199,13 +192,6 @@ public class SketchFragment extends Fragment implements OnDrawChangedListener {
         mColorPicker.setColor(mSketchView.getStrokeColor());
         mColorPicker.setOldCenterColor(mSketchView.getStrokeColor());
     }
-
-
-    @Override
-    public void onPause() {
-        super.onPause();
-    }
-
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {

--- a/omniNotes/src/main/java/it/feio/android/omninotes/async/ONDashClockExtension.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/async/ONDashClockExtension.java
@@ -39,7 +39,7 @@ import java.util.*;
 
 public class ONDashClockExtension extends DashClockExtension {
 
-    private enum Counters {ACTIVE, REMINDERS, TODAY, TOMORROW};
+    private enum Counters {ACTIVE, REMINDERS, TODAY, TOMORROW}
 
 
     private DashClockUpdateReceiver mDashClockReceiver;

--- a/omniNotes/src/main/java/it/feio/android/omninotes/factory/MediaStoreFactory.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/factory/MediaStoreFactory.java
@@ -1,0 +1,22 @@
+package it.feio.android.omninotes.factory;
+
+import android.provider.MediaStore;
+
+import android.net.Uri;
+
+/**
+ * Created by Relf on 11/24/2015.
+ */
+public class MediaStoreFactory {
+    public Uri createURI(String type){
+        switch (type) {
+            case "image":
+                return MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+            case "video":
+                return  MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+            case "audio":
+                return  MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+        }
+        return null;
+    }
+}

--- a/omniNotes/src/main/java/it/feio/android/omninotes/helpers/NotesHelper.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/helpers/NotesHelper.java
@@ -75,7 +75,7 @@ public class NotesHelper {
 				mergedNote.setTitle(note.getTitle());
 				content.append(note.getContent());
 			} else {
-                content = this.appendContent(mergedNote, content);
+                content = appendContent(mergedNote, content);
 			}
 
 			locked = locked || note.isLocked();
@@ -91,8 +91,10 @@ public class NotesHelper {
 			latitude = (Double) ObjectUtils.defaultIfNull(latitude, note.getLatitude());
 			longitude = (Double) ObjectUtils.defaultIfNull(longitude, note.getLongitude());
 
-			this.addAttachments(keepMergedNotes, note);
+			addAttachments(keepMergedNotes, note);
 		}
+
+        setMergedValues(mergedNote);
 
 		return mergedNote;
 	}

--- a/omniNotes/src/main/java/it/feio/android/omninotes/helpers/NotesHelper.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/helpers/NotesHelper.java
@@ -34,20 +34,7 @@ public class NotesHelper {
         return content;
     }
 
-    public static setMergedValues(Note mergedNote) {
-        mergedNote.setContent(content.toString());
-        mergedNote.setLocked(locked);
-        mergedNote.setCategory(category);
-        mergedNote.setAlarm(reminder);
-        mergedNote.setRecurrenceRule(reminderRecurrenceRule);
-        mergedNote.setLatitude(latitude);
-        mergedNote.setLongitude(longitude);
-        mergedNote.setAttachmentsList(attachments);
-
-        return mergedNote;
-    }
-
-    public static void addAttachments(boolean keepMergedNotes, Note note) {
+    public static void addAttachments(boolean keepMergedNotes, Note note, ArrayList<Attachment> attachments) {
         if (keepMergedNotes) {
             for (Attachment attachment : note.getAttachmentsList()) {
                 attachments.add(StorageHelper.createAttachmentFromUri(OmniNotes.getAppContext(), attachment.getUri
@@ -62,7 +49,7 @@ public class NotesHelper {
 		Note mergedNote = null;
 		boolean locked = false;
 		StringBuilder content = new StringBuilder();
-		ArrayList<Attachment> attachments = new ArrayList<>();
+		ArrayList<Attachment> attachments = new ArrayList<Attachment>();
 		Category category = null;
 		String reminder = null;
 		String reminderRecurrenceRule = null;
@@ -91,12 +78,19 @@ public class NotesHelper {
 			latitude = (Double) ObjectUtils.defaultIfNull(latitude, note.getLatitude());
 			longitude = (Double) ObjectUtils.defaultIfNull(longitude, note.getLongitude());
 
-			addAttachments(keepMergedNotes, note);
+			addAttachments(keepMergedNotes, note, attachments);
 		}
 
-        setMergedValues(mergedNote);
+        mergedNote.setContent(content.toString());
+        mergedNote.setLocked(locked);
+        mergedNote.setCategory(category);
+        mergedNote.setAlarm(reminder);
+        mergedNote.setRecurrenceRule(reminderRecurrenceRule);
+        mergedNote.setLatitude(latitude);
+        mergedNote.setLongitude(longitude);
+        mergedNote.setAttachmentsList(attachments);
 
-		return mergedNote;
+        return mergedNote;
 	}
 
 }

--- a/omniNotes/src/main/java/it/feio/android/omninotes/helpers/NotesHelper.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/helpers/NotesHelper.java
@@ -15,8 +15,50 @@ import java.util.List;
 
 public class NotesHelper {
 
-	public static Note mergeNotes(List<Note> notes, boolean keepMergedNotes) {
+    public static StringBuilder appendContent(Note note, StringBuilder content) {
+        if (content.length() > 0
+                && (!TextUtils.isEmpty(note.getTitle()) || !TextUtils.isEmpty(note.getContent()))) {
+            content.append(System.getProperty("line.separator")).append(System.getProperty("line.separator"))
+                    .append(Constants.MERGED_NOTES_SEPARATOR).append(System.getProperty("line.separator"))
+                    .append(System.getProperty("line.separator"));
+        }
+        if (!TextUtils.isEmpty(note.getTitle())) {
+            content.append(note.getTitle());
+        }
+        if (!TextUtils.isEmpty(note.getTitle()) && !TextUtils.isEmpty(note.getContent())) {
+            content.append(System.getProperty("line.separator")).append(System.getProperty("line.separator"));
+        }
+        if (!TextUtils.isEmpty(note.getContent())) {
+            content.append(note.getContent());
+        }
+        return content;
+    }
 
+    public static setMergedValues(Note mergedNote) {
+        mergedNote.setContent(content.toString());
+        mergedNote.setLocked(locked);
+        mergedNote.setCategory(category);
+        mergedNote.setAlarm(reminder);
+        mergedNote.setRecurrenceRule(reminderRecurrenceRule);
+        mergedNote.setLatitude(latitude);
+        mergedNote.setLongitude(longitude);
+        mergedNote.setAttachmentsList(attachments);
+
+        return mergedNote;
+    }
+
+    public static void addAttachments(boolean keepMergedNotes, Note note) {
+        if (keepMergedNotes) {
+            for (Attachment attachment : note.getAttachmentsList()) {
+                attachments.add(StorageHelper.createAttachmentFromUri(OmniNotes.getAppContext(), attachment.getUri
+                        ()));
+            }
+        } else {
+            attachments.addAll(note.getAttachmentsList());
+        }
+    }
+
+	public static Note mergeNotes(List<Note> notes, boolean keepMergedNotes) {
 		Note mergedNote = null;
 		boolean locked = false;
 		StringBuilder content = new StringBuilder();
@@ -32,23 +74,8 @@ public class NotesHelper {
 				mergedNote = new Note();
 				mergedNote.setTitle(note.getTitle());
 				content.append(note.getContent());
-
 			} else {
-				if (content.length() > 0
-						&& (!TextUtils.isEmpty(note.getTitle()) || !TextUtils.isEmpty(note.getContent()))) {
-					content.append(System.getProperty("line.separator")).append(System.getProperty("line.separator"))
-							.append(Constants.MERGED_NOTES_SEPARATOR).append(System.getProperty("line.separator"))
-							.append(System.getProperty("line.separator"));
-				}
-				if (!TextUtils.isEmpty(note.getTitle())) {
-					content.append(note.getTitle());
-				}
-				if (!TextUtils.isEmpty(note.getTitle()) && !TextUtils.isEmpty(note.getContent())) {
-					content.append(System.getProperty("line.separator")).append(System.getProperty("line.separator"));
-				}
-				if (!TextUtils.isEmpty(note.getContent())) {
-					content.append(note.getContent());
-				}
+                content = this.appendContent(mergedNote, content);
 			}
 
 			locked = locked || note.isLocked();
@@ -64,26 +91,10 @@ public class NotesHelper {
 			latitude = (Double) ObjectUtils.defaultIfNull(latitude, note.getLatitude());
 			longitude = (Double) ObjectUtils.defaultIfNull(longitude, note.getLongitude());
 
-			if (keepMergedNotes) {
-				for (Attachment attachment : note.getAttachmentsList()) {
-					attachments.add(StorageHelper.createAttachmentFromUri(OmniNotes.getAppContext(), attachment.getUri
-							()));
-				}
-			} else {
-				attachments.addAll(note.getAttachmentsList());
-			}
+			this.addAttachments(keepMergedNotes, note);
 		}
-
-		// Sets merged values
-		mergedNote.setContent(content.toString());
-		mergedNote.setLocked(locked);
-		mergedNote.setCategory(category);
-		mergedNote.setAlarm(reminder);
-		mergedNote.setRecurrenceRule(reminderRecurrenceRule);
-		mergedNote.setLatitude(latitude);
-		mergedNote.setLongitude(longitude);
-		mergedNote.setAttachmentsList(attachments);
 
 		return mergedNote;
 	}
+
 }

--- a/omniNotes/src/main/java/it/feio/android/omninotes/models/adapters/NoteAdapter.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/models/adapters/NoteAdapter.java
@@ -306,8 +306,7 @@ public class NoteAdapter extends ArrayAdapter<Note> implements Insertable {
         // Overrides font sizes with the one selected from user
         Fonts.overrideTextSize(mActivity, mActivity.getSharedPreferences(Constants.PREFS_NAME,
                 Context.MODE_MULTI_PROCESS), convertView);
-        NoteViewHolder holder = new NoteViewHolder(convertView);
-        return holder;
+        return new NoteViewHolder(convertView);
     }
 
 }

--- a/omniNotes/src/main/java/it/feio/android/omninotes/receiver/AlarmReceiver.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/receiver/AlarmReceiver.java
@@ -110,20 +110,21 @@ public class AlarmReceiver extends BroadcastReceiver {
 						it.feio.android.omninotes.utils.TextHelper.capitalize(mContext.getString(R.string
 								.add_reminder)), piPostpone);
 
-		// Ringtone options
-		String ringtone = prefs.getString("settings_notification_ringtone", null);
-		if (ringtone != null) {
-			notificationsHelper.setRingtone(ringtone);
-		}
+        setAlarm(prefs, notificationsHelper);
 
-		// Vibration options
-		if (prefs.getBoolean("settings_notification_vibration", true)) {
-			notificationsHelper.setVibration();
-		}
+		setVibrate(prefs, notificationsHelper);
 
 		notificationsHelper.show(note.get_id());
 	}
 
+    private void setAlarm(SharedPreferences prefs,NotificationsHelper notificationsHelper) {
+        String ringtone = prefs.getString("settings_notification_ringtone", null);
+        if (ringtone != null) notificationsHelper.setRingtone(ringtone);
+    }
+
+    private void setVibrate(SharedPreferences prefs, NotificationsHelper notificationsHelper) {
+        if (prefs.getBoolean("settings_notification_vibration", true)) notificationsHelper.setVibration();
+    }
 
 	private int getUniqueRequestCode(Note note) {
 		return note.get_id().intValue();

--- a/omniNotes/src/main/java/it/feio/android/omninotes/receiver/AlarmReceiver.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/receiver/AlarmReceiver.java
@@ -110,14 +110,14 @@ public class AlarmReceiver extends BroadcastReceiver {
 						it.feio.android.omninotes.utils.TextHelper.capitalize(mContext.getString(R.string
 								.add_reminder)), piPostpone);
 
-        setAlarm(prefs, notificationsHelper);
+        setRingtone(prefs, notificationsHelper);
 
 		setVibrate(prefs, notificationsHelper);
 
 		notificationsHelper.show(note.get_id());
 	}
 
-    private void setAlarm(SharedPreferences prefs,NotificationsHelper notificationsHelper) {
+    private void setRingtone(SharedPreferences prefs,NotificationsHelper notificationsHelper) {
         String ringtone = prefs.getString("settings_notification_ringtone", null);
         if (ringtone != null) notificationsHelper.setRingtone(ringtone);
     }

--- a/omniNotes/src/main/java/it/feio/android/omninotes/utils/FileHelper.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/utils/FileHelper.java
@@ -25,7 +25,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;
-import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -33,6 +32,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+
+import it.feio.android.omninotes.factory.MediaStoreFactory;
 
 
 public class FileHelper {
@@ -84,19 +85,8 @@ public class FileHelper {
                 final String docId = DocumentsContract.getDocumentId(uri);
                 final String[] split = docId.split(":");
                 final String type = split[0];
-
-                Uri contentUri = null;
-                switch (type) {
-                    case "image":
-                        contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
-                        break;
-                    case "video":
-                        contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
-                        break;
-                    case "audio":
-                        contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
-                        break;
-                }
+                MediaStoreFactory mediaStoreFactory = new MediaStoreFactory();
+                Uri contentUri = mediaStoreFactory.createURI(type);
 
                 final String selection = "_id=?";
                 final String[] selectionArgs = new String[]{split[1]};

--- a/omniNotes/src/main/java/it/feio/android/omninotes/utils/date/DateHelper.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/utils/date/DateHelper.java
@@ -247,9 +247,8 @@ public class DateHelper {
             EventRecurrence recurrenceEvent = new EventRecurrence();
             recurrenceEvent.setStartDate(new Time("" + new Date().getTime()));
             recurrenceEvent.parse(recurrenceRule);
-            String srt = EventRecurrenceFormatter.getRepeatString(mContext.getApplicationContext(),
+            return EventRecurrenceFormatter.getRepeatString(mContext.getApplicationContext(),
                     mContext.getResources(), recurrenceEvent, true);
-            return srt;
         } else {
             return "";
         }


### PR DESCRIPTION
Basic refactoring.

64ba54a:
Sub methods were extracted from the method createNotification within AlarmReceiver.java. The method createNotification was considered as too long and it was handling multiple task, thus, sub methods: setAlarm and setVibrate were extracted.

2185c58:
These methods are inherited from its super class, however the child class is overriding these methods by calling the super. For example, the child class inherited onDestroy(), however, the child class is overriding onDestroy() with super.onDestroy(). By default, if the method is not overridden, then the child class will automatically call the method for its super class, thus the overridden is unnecessary.

081e94c:
Sub methods were extracted from the method mergeNotes within NotesHelper.java. The method mergeNotes was considered as too long and it was handling multiple task, thus, sub methods: appendContent and addAttachments were extracted.

e04c85d:
Fixed bug “this” keyword shouldn’t be in static methods

99598b9:
Fixed few errors & removed unnecessary method

c87e465 & ec89924:
The updateLanguage method contained a nested if-else statement which would split the string if it contained an “_” or use the full string if it didn’t. This code occurs twice for 2 different strings and so the extract method was used to have the string splitting be its own method in order to simplify the updateLanguage method and remove the nested if-else statements.
Because the split() method returns the full string if the string does not contain the character within the parameter, the setLanaguageString method was removed and the string splitting is done within the parameter of the Locale initialization.

139e828:
A new package is created for all the factory classes. MediaStoreFactory has been created inside the factory package. The factory class will return the correct content uri, based on the string that we passed into this factory. This will improve cohesion for the FileHelper, as it has less responsibility now, since the factory is handling the creation of content uri.

89114d3:
Firstly, the import for android.provider.MediaStore is removed, because FileHelper no longer depends or needs to get uri from MediaStore. The switch statement is removed and is replaced, as we are now using the factory to get the needed uri.