### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expression…

### DIFF
--- a/omniNotes/src/main/java/it/feio/android/omninotes/widget/ListRemoteViewsFactory.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/widget/ListRemoteViewsFactory.java
@@ -137,25 +137,25 @@ public class ListRemoteViewsFactory implements RemoteViewsFactory {
         // action of a given item
         row.setOnClickFillInIntent(R.id.root, fillInIntent);
 
-        return (row);
+        return row;
     }
 
 
     @Override
     public RemoteViews getLoadingView() {
-        return (null);
+        return null;
     }
 
 
     @Override
     public int getViewTypeCount() {
-        return (1);
+        return 1;
     }
 
 
     @Override
     public long getItemId(int position) {
-        return (position);
+        return position;
     }
 
 

--- a/omniNotes/src/main/java/it/feio/android/omninotes/widget/ListWidgetService.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/widget/ListWidgetService.java
@@ -28,6 +28,6 @@ public class ListWidgetService extends RemoteViewsService {
 
     @Override
     public RemoteViewsFactory onGetViewFactory(Intent intent) {
-        return (new ListRemoteViewsFactory(this.getApplication(), intent));
+        return new ListRemoteViewsFactory(this.getApplication(), intent);
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava