### PR TITLE
Multiple code improvements: squid:S00100, squid:S2118, squid:S1444

### DIFF
--- a/omniNotes/src/main/java/it/feio/android/omninotes/models/SerializableHashMap.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/models/SerializableHashMap.java
@@ -1,0 +1,10 @@
+package it.feio.android.omninotes.models;
+
+import java.util.HashMap;
+
+import it.feio.android.omninotes.models.SerializableMap;
+
+/**
+ * Created by georgekankava on 3/3/16.
+ */
+public class SerializableHashMap<K, V> extends HashMap<K, V> implements SerializableMap<K, V> {}

--- a/omniNotes/src/main/java/it/feio/android/omninotes/models/SerializableMap.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/models/SerializableMap.java
@@ -1,0 +1,9 @@
+package it.feio.android.omninotes.models;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * Created by georgekankava on 3/3/16.
+ */
+public interface SerializableMap<K, V> extends Map<K, V>, Serializable {}

--- a/omniNotes/src/main/java/it/feio/android/omninotes/models/listeners/OnFabItemClickedListener.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/models/listeners/OnFabItemClickedListener.java
@@ -19,5 +19,5 @@ package it.feio.android.omninotes.models.listeners;
 
 public interface OnFabItemClickedListener {
 
-    void OnFabItemClick(int id);
+    void onFabItemClick(int id);
 }

--- a/omniNotes/src/main/java/it/feio/android/omninotes/models/views/Fab.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/models/views/Fab.java
@@ -19,7 +19,6 @@ import it.feio.android.omninotes.models.listeners.AbsListViewScrollDetector;
 import it.feio.android.omninotes.models.listeners.OnFabItemClickedListener;
 import it.feio.android.omninotes.utils.Constants;
 import it.feio.android.omninotes.utils.Display;
-import it.feio.android.omninotes.utils.Navigation;
 
 import static android.support.v4.view.ViewCompat.animate;
 
@@ -104,7 +103,7 @@ public class Fab {
     private View.OnClickListener onClickListener = new View.OnClickListener() {
         @Override
         public void onClick(View v) {
-            onFabItemClickedListener.OnFabItemClick(v.getId());
+            onFabItemClickedListener.onFabItemClick(v.getId());
         }
     };
 
@@ -130,7 +129,7 @@ public class Fab {
             fab.toggle();
             fabExpanded = false;
         } else {
-            onFabItemClickedListener.OnFabItemClick(v.getId());
+            onFabItemClickedListener.onFabItemClick(v.getId());
         }
     }
 

--- a/omniNotes/src/main/java/it/feio/android/omninotes/utils/SimpleDiskCache.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/utils/SimpleDiskCache.java
@@ -39,9 +39,10 @@ import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import it.feio.android.omninotes.models.SerializableHashMap;
+import it.feio.android.omninotes.models.SerializableMap;
 
 
 public class SimpleDiskCache {
@@ -112,11 +113,11 @@ public class SimpleDiskCache {
 
 
     public OutputStream openStream(String key) throws IOException {
-        return openStream(key, new HashMap<String, Serializable>());
+        return openStream(key, new SerializableHashMap<String, Serializable>());
     }
 
 
-    public OutputStream openStream(String key, Map<String, ? extends Serializable> metadata)
+    public OutputStream openStream(String key, SerializableMap<String, ? extends Serializable> metadata)
             throws IOException {
         DiskLruCache.Editor editor = diskLruCache.edit(toInternalKey(key));
         try {
@@ -131,11 +132,11 @@ public class SimpleDiskCache {
 
 
     public void put(String key, InputStream is) throws IOException {
-        put(key, is, new HashMap<String, Serializable>());
+        put(key, is, new SerializableHashMap<String, Serializable>());
     }
 
 
-    public void put(String key, InputStream is, Map<String, Serializable> annotations)
+    public void put(String key, InputStream is, SerializableHashMap<String, Serializable> annotations)
             throws IOException {
         OutputStream os = null;
         try {
@@ -148,11 +149,11 @@ public class SimpleDiskCache {
 
 
     public void put(String key, String value) throws IOException {
-        put(key, value, new HashMap<String, Serializable>());
+        put(key, value, new SerializableHashMap<String, Serializable>());
     }
 
 
-    public void put(String key, String value, Map<String, ? extends Serializable> annotations)
+    public void put(String key, String value, SerializableMap<String, ? extends Serializable> annotations)
             throws IOException {
         OutputStream cos = null;
         try {
@@ -165,7 +166,7 @@ public class SimpleDiskCache {
     }
 
 
-    private void writeMetadata(Map<String, ? extends Serializable> metadata,
+    private void writeMetadata(SerializableMap<String, ? extends Serializable> metadata,
                                DiskLruCache.Editor editor) throws IOException {
         ObjectOutputStream oos = null;
         try {

--- a/omniNotes/src/main/java/it/feio/android/omninotes/widget/WidgetProvider.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/widget/WidgetProvider.java
@@ -37,9 +37,9 @@ import it.feio.android.omninotes.utils.Constants;
 
 public abstract class WidgetProvider extends AppWidgetProvider {
 
-    public static String EXTRA_WORD = "it.feio.android.omninotes.widget.WORD";
-    public static String TOAST_ACTION = "it.feio.android.omninotes.widget.NOTE";
-    public static String EXTRA_ITEM = "it.feio.android.omninotes.widget.EXTRA_FIELD";
+    public static final String EXTRA_WORD = "it.feio.android.omninotes.widget.WORD";
+    public static final String TOAST_ACTION = "it.feio.android.omninotes.widget.NOTE";
+    public static final String EXTRA_ITEM = "it.feio.android.omninotes.widget.EXTRA_FIELD";
 
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00100 - Method names should comply with a naming convention.
squid:S2118 - Non-serializable classes should not be written.
squid:S1444 - "public static" fields should be constant.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00100
https://dev.eclipse.org/sonar/rules/show/squid:S2118
https://dev.eclipse.org/sonar/rules/show/squid:S1444
Please let me know if you have any questions.
George Kankava