### PR TITLE
More descriptive beta programme setting

### DIFF
--- a/omniNotes/src/main/res/values/strings.xml
+++ b/omniNotes/src/main/res/values/strings.xml
@@ -279,8 +279,8 @@
     <string name="settings_category_preferences">Preferences</string>
     <string name="settings_category_beta">Beta</string>
     <string name="settings_category_about">About</string>
-    <string name="settings_beta">Google+</string>
-    <string name="settings_beta_summary">Subscribe to the beta program to keep up to date with the latest features</string>
+    <string name="settings_beta">Join the beta program</string>
+    <string name="settings_beta_summary">Subscribe to the beta program via Google+ to access the latest features and to help develop Omni Notes</string>
     <string name="donate">Donate</string>
     <string name="donate_summary">Support the development of this app with a non-profit donation</string>
     <string name="settings_choose_language">Language</string>


### PR DESCRIPTION
adjust title & description; use goal rather than means for the title.
Most users tend to skip the subheadings, so a descriptive title is necessary.