### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The project was created by the absence of such applications compatible with old 
 <a href="https://play.google.com/store/apps/details?id=it.feio.android.omninotes" target="_blank">
 <img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" alt="Get it on Google Play" height="90"/></a>
 
-##Features
+## Features
 
 Actually the following functions are implemented:
 
@@ -111,7 +111,7 @@ They're all listed into the [build.gradle](https://github.com/federicoiosue/Omni
 * https://github.com/mrmans0n/smart-location-lib
 
 
-##Contributing
+## Contributing
 
 Due to the fact that I'm using [gitflow](https://github.com/nvie/gitflow) as code versioning methodology you, as developer should **always** start working on [develop branch](https://github.com/federicoiosue/Omni-Notes/tree/develop) that contains the most recent changes.
 
@@ -120,7 +120,7 @@ Feel free to add yourself to [contributors.md](https://github.com/federicoiosue/
 **Don't forget to contribute to original code! Don't be selfish or lazy!**
 
 
-##Developed with love and passion by
+## Developed with love and passion by
 
 
 * Federico Iosue - [Website](http://www.iosue.it/federico)
@@ -128,7 +128,7 @@ Feel free to add yourself to [contributors.md](https://github.com/federicoiosue/
 
 
 
-##License
+## License
 
 
     Copyright 2015 Federico Iosue


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
