### PR TITLE
Changed card layout on the widget to wrap content

### DIFF
--- a/omniNotes/src/main/res/layout/note_layout_widget.xml
+++ b/omniNotes/src/main/res/layout/note_layout_widget.xml
@@ -18,14 +18,14 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/root"
     android:layout_width="match_parent"
-    android:layout_height="80dp"
+    android:layout_height="wrap_content"
     android:background="@drawable/bg_card"
     android:paddingBottom="2dp" >
 
     <LinearLayout
         android:id="@+id/card_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="horizontal" >
 
         <TextView
@@ -66,7 +66,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom|right"
-                android:singleLine="true"
                 android:textAppearance="@style/Text.Normal.Widget"
                 android:textColor="@color/list_note_title" />
 


### PR DESCRIPTION
As I mentioned in the other pull request, the entire note content is squished into a single line on the widget. I believe the expectation of the user would be to view different lines of text/items of a list separated by line breaks. Just a couple of lines were necessary to change the behavior, so that the card heights adapt to the content of the note.

It seemed, however, that to keep everything in the same line was a design decision. If so, I would suggest at least adding the possibility to toggle between "compact and expanded" displays of the widget.
(By the way, I tested these changes and the ones from the previous pull request on a Moto G 2014)

Cheers!
Marcel