### PR TITLE
Request permission before attempting to import from a backup

### DIFF
--- a/omniNotes/src/main/java/it/feio/android/omninotes/SettingsFragment.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/SettingsFragment.java
@@ -152,7 +152,8 @@ public class SettingsFragment extends PreferenceFragment {
 		Preference importData = findPreference("settings_import_data");
 		if (importData != null) {
 			importData.setOnPreferenceClickListener(arg0 -> {
-				importNotes();
+				PermissionsHelper.requestPermission(getActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE, R
+						.string.permission_external_storage, activity.findViewById(R.id.crouton_handle), () -> importNotes());
 				return false;
 			});
 		}


### PR DESCRIPTION
After installing, if permission to access storage is not granted and a restore from a backup is attempted, the app crashes. This does not happen when attempting to backup, however (the app requests permission again and does not crash when not allowed). I copied the behavior from backup to restore, and it works as expected on my phone (the app doesn't crash anymore).