### PR TITLE
fixed #371 #339 widget shows deleted and archived note

### DIFF
--- a/omniNotes/src/main/java/it/feio/android/omninotes/ListFragment.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/ListFragment.java
@@ -1678,8 +1678,6 @@ public class ListFragment extends BaseFragment implements OnViewTouchedListener,
 
             ubc.hideUndoBar(false);
             fab.showFab();
-
-            BaseActivity.notifyAppWidgets(mainActivity);
             Log.d(Constants.TAG, "Changes committed");
         }
     }

--- a/omniNotes/src/main/java/it/feio/android/omninotes/async/notes/NoteProcessor.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/async/notes/NoteProcessor.java
@@ -19,11 +19,14 @@ package it.feio.android.omninotes.async.notes;
 
 import android.os.AsyncTask;
 import de.greenrobot.event.EventBus;
-import it.feio.android.omninotes.async.bus.NotesUpdatedEvent;
-import it.feio.android.omninotes.models.Note;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import it.feio.android.omninotes.BaseActivity;
+import it.feio.android.omninotes.OmniNotes;
+import it.feio.android.omninotes.async.bus.NotesUpdatedEvent;
+import it.feio.android.omninotes.models.Note;
 
 
 public abstract class NoteProcessor {
@@ -60,6 +63,7 @@ public abstract class NoteProcessor {
 		@Override
 		protected void onPostExecute(Void aVoid) {
 			EventBus.getDefault().post(new NotesUpdatedEvent());
+			BaseActivity.notifyAppWidgets(OmniNotes.getAppContext());
 		}
 	}
 }


### PR DESCRIPTION
In my KitKat this bug did not show up, but after restore note from archive or trash widget did not update. In Marshmallow emulator this issue was appeared. I think because AsyncTask does not finish work before BaseActivity.notifyAppWidgets started.