### PR TITLE
close #379 issue return to the note list after open note from widget

### DIFF
--- a/omniNotes/src/main/java/it/feio/android/omninotes/MainActivity.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/MainActivity.java
@@ -157,10 +157,10 @@ public class MainActivity extends BaseActivity implements OnDateSetListener, OnT
         if (intent.getAction() == null) {
             intent.setAction(Constants.ACTION_START_APP);
         }
+        super.onNewIntent(intent);
         setIntent(intent);
         handleIntents();
         Log.d(Constants.TAG, "onNewIntent");
-        super.onNewIntent(intent);
     }
 
 
@@ -409,11 +409,14 @@ public class MainActivity extends BaseActivity implements OnDateSetListener, OnT
         b.putParcelable(Constants.INTENT_NOTE, note);
         mDetailFragment.setArguments(b);
         if (mFragmentManager.findFragmentByTag(FRAGMENT_DETAIL_TAG) == null) {
-            transaction.replace(R.id.fragment_container, mDetailFragment, FRAGMENT_DETAIL_TAG).addToBackStack
-                    (FRAGMENT_LIST_TAG).commitAllowingStateLoss();
+            transaction.replace(R.id.fragment_container, mDetailFragment, FRAGMENT_DETAIL_TAG)
+                    .addToBackStack(FRAGMENT_LIST_TAG)
+                    .commitAllowingStateLoss();
         } else {
-            transaction.replace(R.id.fragment_container, mDetailFragment, FRAGMENT_DETAIL_TAG).addToBackStack
-                    (FRAGMENT_DETAIL_TAG).commitAllowingStateLoss();
+            mFragmentManager.popBackStackImmediate();
+            transaction.replace(R.id.fragment_container, mDetailFragment, FRAGMENT_DETAIL_TAG)
+                    .addToBackStack(FRAGMENT_DETAIL_TAG)
+                    .commitAllowingStateLoss();
         }
     }
 


### PR DESCRIPTION
After this patch, behavior the stack of notes changed. When  open the note from widget and then tap arrow on an action bar, list of notes appears instead of a previously opened note. And this solution match for wishes from the last [comment from jgbreezer ](https://github.com/federicoiosue/Omni-Notes/issues/347#issuecomment-352564701) 