### PR TITLE
Fix bottom line "Updated:" doesn't fit in the widget

### DIFF
--- a/omniNotes/src/main/res/layout/note_layout_widget.xml
+++ b/omniNotes/src/main/res/layout/note_layout_widget.xml
@@ -40,7 +40,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:orientation="vertical"
-            android:paddingBottom="12dp"
+            android:paddingBottom="2dp"
             android:paddingLeft="6dp"
             android:paddingRight="16dp"
             android:paddingTop="4dp" >


### PR DESCRIPTION
When widget became with two row, Label "updated:"  doesn't fit in the widget. It may be worth adding the creation date to the right of the update date