### PR TITLE
Feature/add-note-ux-improvement

### DIFF
--- a/omniNotes/src/androidTest/java/it/feio/android/omninotes/AddAndEditNoteTest.java
+++ b/omniNotes/src/androidTest/java/it/feio/android/omninotes/AddAndEditNoteTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 Federico Iosue (federico.iosue@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundatibehaon, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package it.feio.android.omninotes;
+
+import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withParent;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+
+/**
+ * Created by AchrafAmil on 05/04/2018.
+ */
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class AddAndEditNoteTest extends BaseEspressoTest {
+
+    @Test
+    public void AddNote(){
+        onView(allOf(withId(R.id.fab_expand_menu_button),
+                withParent(withId(R.id.fab)),
+                isDisplayed()))
+                .perform(click());
+
+        onView(allOf(withId(R.id.fab_note),
+                withParent(withId(R.id.fab)),
+                isDisplayed()))
+                .perform(click());
+
+        onView(withId(R.id.detail_title))
+                .perform(typeText("Foobar title"));
+
+        onView(withId(R.id.detail_content))
+                .perform(typeText("Lorem Ipsum"));
+
+        onView(withId(R.id.done_fab))
+                .perform(click());
+
+        onView(withText("Foobar title"))
+                .check(matches(isDisplayed()));
+
+    }
+
+}

--- a/omniNotes/src/androidTest/java/it/feio/android/omninotes/AddAndEditNoteTest.java
+++ b/omniNotes/src/androidTest/java/it/feio/android/omninotes/AddAndEditNoteTest.java
@@ -47,7 +47,7 @@ import static org.hamcrest.Matchers.allOf;
 public class AddAndEditNoteTest extends BaseEspressoTest {
 
     @Test
-    public void AddNote(){
+    public void addNote(){
         onView(allOf(withId(R.id.fab_expand_menu_button),
                 withParent(withId(R.id.fab)),
                 isDisplayed()))
@@ -78,7 +78,7 @@ public class AddAndEditNoteTest extends BaseEspressoTest {
      * Then I can see empty fields and focus is on content field (keyboard is shown.
      */
     @Test
-    public void AddNote_ShouldFocusOnContent(){
+    public void addNoteShouldFocusOnContent(){
 
         onView(allOf(withId(R.id.fab_expand_menu_button),
                 withParent(withId(R.id.fab)),

--- a/omniNotes/src/androidTest/java/it/feio/android/omninotes/AddAndEditNoteTest.java
+++ b/omniNotes/src/androidTest/java/it/feio/android/omninotes/AddAndEditNoteTest.java
@@ -19,7 +19,12 @@ package it.feio.android.omninotes;
 
 import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.LargeTest;
+import android.view.View;
+import android.widget.TextView;
 
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -67,4 +72,44 @@ public class AddAndEditNoteTest extends BaseEspressoTest {
 
     }
 
+    /**
+     * Given I'm at note list (MainActivity)
+     * When I press add new note
+     * Then I can see empty fields and focus is on content field (keyboard is shown.
+     */
+    @Test
+    public void AddNote_ShouldFocusOnContent(){
+
+        onView(allOf(withId(R.id.fab_expand_menu_button),
+                withParent(withId(R.id.fab)),
+                isDisplayed()))
+                .perform(click());
+
+        onView(allOf(withId(R.id.fab_note),
+                withParent(withId(R.id.fab)),
+                isDisplayed()))
+                .perform(click());
+
+        onView(withId(R.id.detail_content))
+                .check(matches(isTextFocused()));
+
+    }
+
+
+    public static Matcher<View> isTextFocused() {
+        return new TypeSafeMatcher<View>() {
+
+            @Override
+            public boolean matchesSafely(View view) {
+                if (!(view instanceof TextView)) {
+                    return false;
+                }
+                return (view).isFocused();
+            }
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("is-focused=true");
+            }
+        };
+    }
 }

--- a/omniNotes/src/main/java/it/feio/android/omninotes/DetailFragment.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/DetailFragment.java
@@ -372,8 +372,9 @@ public class DetailFragment extends BaseFragment implements OnReminderPickedList
 
 		initViews();
 
-		if(content.getText().length()==0)
+		if(content.getText().length()==0){
 			focusOnContent();
+		}
 	}
 
 	private void focusOnContent(){

--- a/omniNotes/src/main/java/it/feio/android/omninotes/DetailFragment.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/DetailFragment.java
@@ -21,6 +21,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.DatePickerDialog.OnDateSetListener;
 import android.app.TimePickerDialog.OnTimeSetListener;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
@@ -61,6 +62,7 @@ import android.view.View.OnTouchListener;
 import android.view.animation.Animation;
 import android.view.animation.Animation.AnimationListener;
 import android.view.animation.AnimationUtils;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.*;
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -369,6 +371,17 @@ public class DetailFragment extends BaseFragment implements OnReminderPickedList
 		}
 
 		initViews();
+
+		if(content.getText().length()==0)
+			focusOnContent();
+	}
+
+	private void focusOnContent(){
+		Log.e(Constants.TAG, "focusing on note content EditText (and showing keyboard)");
+		content.setFocusableInTouchMode(true);
+		content.requestFocus();
+		InputMethodManager inputMethodManager=(InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+		inputMethodManager.showSoftInput(content,0);
 	}
 
 

--- a/omniNotes/src/main/java/it/feio/android/omninotes/DetailFragment.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/DetailFragment.java
@@ -43,6 +43,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.provider.MediaStore;
 import android.support.annotation.Nullable;
+import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.util.Pair;
@@ -169,6 +170,8 @@ public class DetailFragment extends BaseFragment implements OnReminderPickedList
 	ViewManager detailWrapperView;
 	@BindView(R.id.snackbar_placeholder)
 	View snackBarPlaceholder;
+	@BindView(R.id.done_fab)
+	FloatingActionButton doneFab;
 
 	public OnDateSetListener onDateSetListener;
 	public OnTimeSetListener onTimeSetListener;
@@ -528,8 +531,18 @@ public class DetailFragment extends BaseFragment implements OnReminderPickedList
 		initViewReminder();
 
 		initViewFooter();
+
+		initViewDoneFab();
 	}
 
+	private void initViewDoneFab(){
+		doneFab.setOnClickListener(new OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				saveAndExit(DetailFragment.this);
+			}
+		});
+	}
 
 	private void initViewFooter() {
 		// Footer dates of creation...

--- a/omniNotes/src/main/res/drawable-nodpi/ic_done.xml
+++ b/omniNotes/src/main/res/drawable-nodpi/ic_done.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z" />
+</vector>

--- a/omniNotes/src/main/res/layout/fragment_detail.xml
+++ b/omniNotes/src/main/res/layout/fragment_detail.xml
@@ -15,6 +15,7 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
                 xmlns:pixlui="http://schemas.android.com/apk/com.neopixl.pixlui"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
@@ -116,6 +117,18 @@
 
                     </LinearLayout>
                 </ScrollView>
+
+                <android.support.design.widget.FloatingActionButton
+                    android:id="@+id/done_fab"
+                    app:srcCompat="@drawable/ic_done"
+                    app:fabSize="normal"
+                    app:layout_anchor="@id/content_wrapper"
+                    app:layout_anchorGravity="bottom|right|end"
+                    android:layout_margin="@dimen/fab_right_margin"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:elevation="8dp"/>
+
             </android.support.design.widget.CoordinatorLayout>
 
             <LinearLayout


### PR DESCRIPTION
**Creating a note**
**before:** press the "+" fab, press the "Text note" fab, press content, write note, press back button.
**now:** press the "+" fab, press the "Text note" fab, write note, press "✓" fab.

**changes**
- the "✓" fab to save & exit.
- focus on content EditText if it's empty (new note, or existing note with empty content (only a title)) and show keyboard -> ready to type.
- UI Test: adding a new note using the new fab.
- UI Test: add new note and assert 'content' has focus.