### PR TITLE
Bug Fix: Remove Title From Contents Sections of Merged Note

### DIFF
--- a/omniNotes/src/main/java/it/feio/android/omninotes/helpers/NotesHelper.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/helpers/NotesHelper.java
@@ -29,9 +29,6 @@ public class NotesHelper {
                     .append(Constants.MERGED_NOTES_SEPARATOR).append(System.getProperty("line.separator"))
                     .append(System.getProperty("line.separator"));
         }
-        if (!TextUtils.isEmpty(note.getTitle())) {
-            content.append(note.getTitle());
-        }
         if (!TextUtils.isEmpty(note.getTitle()) && !TextUtils.isEmpty(note.getContent())) {
             content.append(System.getProperty("line.separator")).append(System.getProperty("line.separator"));
         }


### PR DESCRIPTION
Fix for #468. This removes the title of every selected note from the contents section of the merged note.