### PR TITLE
Ignore case to sort note list

### DIFF
--- a/omniNotes/src/main/java/it/feio/android/omninotes/db/DbHelper.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/db/DbHelper.java
@@ -412,7 +412,7 @@ public class DbHelper extends SQLiteOpenHelper {
                 + " FROM " + TABLE_NOTES
                 + " LEFT JOIN " + TABLE_CATEGORY + " USING( " + KEY_CATEGORY + ") "
                 + whereCondition
-                + (order ? " ORDER BY " + sort_column + sort_order : "");
+                + (order ? " ORDER BY " + sort_column + " COLLATE NOCASE " + sort_order : "");
 
         Log.v(Constants.TAG, "Query: " + query);
 


### PR DESCRIPTION
When SQLite compares two strings, it uses a collating sequence to determine which string is greater. The NOCASE collating functions is the same as BYNARY (default), except the 26 upper case characters of ASCII are folded to their lower case equivalents.
Issue #542