### PR TITLE
Fix crash while switching to reduced note layout 

### DIFF
--- a/omniNotes/src/androidTest/java/it/feio/android/omninotes/ui/NoteListMenuTest.java
+++ b/omniNotes/src/androidTest/java/it/feio/android/omninotes/ui/NoteListMenuTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2013-2020 Federico Iosue (federico@iosue.it)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package it.feio.android.omninotes.ui;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import it.feio.android.omninotes.R;
+import it.feio.android.omninotes.utils.Constants;
+import it.feio.android.omninotes.utils.ConstantsBase;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class NoteListMenuTest  extends BaseEspressoTest  {
+
+   @Test
+   public void switchExpandedColapsedNoteLayoutTest () {
+
+      prefs.edit().putBoolean(Constants.PREF_EXPANDED_VIEW, false).apply();
+
+      createNote("A Title", "A content");
+
+      // click overflow menu button
+      openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+
+      // click expanded view menu item
+      onView(withText(R.string.expanded_view))
+              .perform(click());
+
+      openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+
+      onView(withText(R.string.contracted_view))
+              .perform(click());
+   }
+}

--- a/omniNotes/src/main/java/it/feio/android/omninotes/models/adapters/NoteAdapter.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/models/adapters/NoteAdapter.java
@@ -299,7 +299,13 @@ public class NoteAdapter extends RecyclerView.Adapter<NoteViewHolder> {
   @NonNull
   @Override
   public NoteViewHolder onCreateViewHolder (@NonNull ViewGroup parent, int viewType) {
-    View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.note_layout_expanded, parent, false);
+    View view;
+    if (expandedView) {
+      view = LayoutInflater.from(parent.getContext()).inflate(R.layout.note_layout_expanded, parent, false);
+    } else {
+      view = LayoutInflater.from(parent.getContext()).inflate(R.layout.note_layout, parent, false);
+    }
+
     return new NoteViewHolder(view);
   }
 


### PR DESCRIPTION
Expanded note layout was always created, independent from setting