### PR TITLE
Sync reminder with calendar button

### DIFF
--- a/omniNotes/src/androidTest/java/it/feio/android/omninotes/ui/CalendarReminderSyncTest.java
+++ b/omniNotes/src/androidTest/java/it/feio/android/omninotes/ui/CalendarReminderSyncTest.java
@@ -1,0 +1,75 @@
+package it.feio.android.omninotes.ui;
+
+import androidx.test.espresso.matcher.ViewMatchers;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import it.feio.android.omninotes.R;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.longClick;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withParent;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.not;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class CalendarReminderSyncTest extends BaseEspressoTest {
+
+	@Test
+	public void syncButtonAppears() throws InterruptedException {
+		Thread.sleep(1500);
+
+		onView(Matchers.allOf(ViewMatchers.withId(R.id.fab_expand_menu_button),
+				withParent(withId(R.id.fab)),
+				isDisplayed())).perform(click());
+
+		onView(allOf(withId(R.id.fab_note),
+				withParent(withId(R.id.fab)),
+				isDisplayed())).perform(click());
+
+		onView(withId(R.id.reminder_layout)).perform(scrollTo(), click());
+		onView(allOf(withId(R.id.buttonPositive), withText("Ok"), isDisplayed())).perform(click());
+		onView(withId(R.id.sync_reminder_layout)).check(matches(isDisplayed()));
+
+		Thread.sleep(1500);
+
+	}
+
+	@Test
+	public void syncButtonDisappears() throws InterruptedException {
+		Thread.sleep(1500);
+
+		onView(Matchers.allOf(ViewMatchers.withId(R.id.fab_expand_menu_button),
+				withParent(withId(R.id.fab)),
+				isDisplayed())).perform(click());
+
+		onView(allOf(withId(R.id.fab_note),
+				withParent(withId(R.id.fab)),
+				isDisplayed())).perform(click());
+
+		onView(withId(R.id.reminder_layout)).perform(scrollTo(), click());
+		onView(allOf(withId(R.id.buttonPositive), withText("Ok"), isDisplayed())).perform(click());
+
+		onView(withId(R.id.reminder_layout)).perform(scrollTo(), longClick());
+		onView(withText("Ok"))
+				.inRoot(isDialog())
+				.check(matches(isDisplayed()))
+				.perform(click());
+
+		onView(withId(R.id.sync_reminder_layout)).check(matches(not(isDisplayed())));
+
+		Thread.sleep(1500);
+
+	}
+
+}

--- a/omniNotes/src/main/java/it/feio/android/omninotes/DetailFragment.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/DetailFragment.java
@@ -200,7 +200,7 @@ public class DetailFragment extends BaseFragment implements OnReminderPickedList
   private static final int CATEGORY = 5;
   private static final int DETAIL = 6;
   private static final int FILES = 7;
-  //private static final int GCALENDAR = 8;
+  private static final int GCALENDAR = 8;
 
   private FragmentDetailBinding binding;
 
@@ -614,8 +614,6 @@ public class DetailFragment extends BaseFragment implements OnReminderPickedList
     }
   }
 
-
-  //TODO make the sync button appear only if there's a reminder
   private void initViewReminder() {
     binding.fragmentDetailContent.reminderLayout.setOnClickListener(v -> {
       ReminderPickers reminderPicker = new ReminderPickers(mainActivity, mFragment);
@@ -653,20 +651,8 @@ public class DetailFragment extends BaseFragment implements OnReminderPickedList
       syncReminder();
     });
 
-    //TODO Remove calendar event
-    binding.fragmentDetailContent.syncReminderLayout.setOnLongClickListener(v -> {
-      MaterialDialog dialog = new MaterialDialog.Builder(mainActivity)
-              .content(R.string.remove_calendar_event)
-              .positiveText(R.string.ok)
-              .onPositive((dialog1, which) -> {
-                System.out.println("Calendar event removed!");
-              }).build();
-      dialog.show();
-      return true;
-    });
-
     //Sync Reminder
-    if(noteTmp.getAlarm() != null)
+    if (noteTmp.getAlarm() != null)
       binding.fragmentDetailContent.syncReminderLayout.setVisibility(View.VISIBLE);
     else
       binding.fragmentDetailContent.syncReminderLayout.setVisibility(View.GONE);
@@ -1139,19 +1125,19 @@ public class DetailFragment extends BaseFragment implements OnReminderPickedList
     return super.onOptionsItemSelected(item);
   }
 
-  private void syncReminder() {
+  private void syncReminder () {
 
     //First save the note, them call the calendar intent
     saveNote(this);
 
     Intent intent = new Intent(Intent.ACTION_INSERT)
-      .setData(CalendarContract.Events.CONTENT_URI)
-      .putExtra(CalendarContract.Events.TITLE, noteTmp.getTitle())
-      .putExtra(CalendarContract.Events.DESCRIPTION, noteTmp.getContent())
-      .putExtra(CalendarContract.Events.EVENT_LOCATION, noteTmp.getAddress())
-      .putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, parseLong(noteTmp.getAlarm()))
-      .putExtra(CalendarContract.EXTRA_EVENT_END_TIME, parseLong(noteTmp.getAlarm()))
-      .putExtra(CalendarContract.Events.RRULE, noteTmp.getRecurrenceRule());
+        .setData(CalendarContract.Events.CONTENT_URI)
+        .putExtra(CalendarContract.Events.TITLE, noteTmp.getTitle())
+        .putExtra(CalendarContract.Events.DESCRIPTION, noteTmp.getContent())
+        .putExtra(CalendarContract.Events.EVENT_LOCATION, noteTmp.getAddress())
+        .putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, parseLong(noteTmp.getAlarm()))
+        .putExtra(CalendarContract.EXTRA_EVENT_END_TIME, parseLong(noteTmp.getAlarm()))
+        .putExtra(CalendarContract.Events.RRULE, noteTmp.getRecurrenceRule());
 
     startActivity(intent);
   }

--- a/omniNotes/src/main/res/drawable/ic_baseline_calendar_today_24.xml
+++ b/omniNotes/src/main/res/drawable/ic_baseline_calendar_today_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M20,3h-1L19,1h-2v2L7,3L7,1L5,1v2L4,3c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,5c0,-1.1 -0.9,-2 -2,-2zM20,21L4,21L4,8h16v13z"/>
+</vector>

--- a/omniNotes/src/main/res/drawable/ic_baseline_sync_24.xml
+++ b/omniNotes/src/main/res/drawable/ic_baseline_sync_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,4L12,1L8,5l4,4L12,6c3.31,0 6,2.69 6,6 0,1.01 -0.25,1.97 -0.7,2.8l1.46,1.46C19.54,15.03 20,13.57 20,12c0,-4.42 -3.58,-8 -8,-8zM12,18c-3.31,0 -6,-2.69 -6,-6 0,-1.01 0.25,-1.97 0.7,-2.8L5.24,7.74C4.46,8.97 4,10.43 4,12c0,4.42 3.58,8 8,8v3l4,-4 -4,-4v3z"/>
+</vector>

--- a/omniNotes/src/main/res/layout/fragment_detail_content.xml
+++ b/omniNotes/src/main/res/layout/fragment_detail_content.xml
@@ -96,4 +96,41 @@
       android:textColor="@color/text_color_lighter"
       pixlui:typeface="Roboto-Regular.ttf" />
   </LinearLayout>
+
+  <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:orientation="horizontal"
+      android:id="@+id/sync_reminder_layout"
+      android:layout_marginBottom="5dp"
+      android:background="@drawable/icon_selector"
+      android:paddingBottom="10dp"
+      android:paddingTop="10dp"
+      android:paddingStart="@dimen/padding_half"
+      android:paddingLeft="@dimen/padding_half"
+      android:gravity="center_vertical">
+
+    <ImageView
+        android:id="@+id/cal_sync_icon"
+        android:layout_height="20dp"
+        android:layout_width="20dp"
+        android:layout_marginEnd="5dp"
+        android:layout_marginRight="5dp"
+        android:contentDescription="@string/sync_reminder"
+        android:src="@drawable/ic_baseline_sync_24" />
+
+    <com.neopixl.pixlui.components.textview.TextView
+        android:id="@+id/sync_prompt"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:freezesText="true"
+        android:gravity="center_vertical"
+        android:hint="@string/sync_reminder"
+        android:textAppearance="@style/Text.Small"
+        android:textColorHint="@color/text_color_lighter"
+        android:textColor="@color/text_color_lighter"
+        pixlui:typeface="Roboto-Regular.ttf" />
+
+  </LinearLayout>
+
 </LinearLayout>

--- a/omniNotes/src/main/res/values/strings.xml
+++ b/omniNotes/src/main/res/values/strings.xml
@@ -229,7 +229,7 @@
   <string name="completed">Completed</string>
   <string name="undo_changes_note_confirmation">Confirm undoing changes?</string>
   <string name="done">Done</string>
-  <string name="sync_reminder">Sync reminder with Google Calendar</string>
+  <string name="sync_reminder">Sync reminder with Calendar</string>
 
   <!-- Settings -->
   <string name="dashclock_description">Displays some statistics and expiring reminders from Omni Notes</string>
@@ -436,5 +436,6 @@
   <string name="channel_pinned_name">Pinned</string>
   <string name="channel_pinned_description">Notifications for pinned notes</string>
   <string name="remove_calendar_event">Remove calendar event?</string>
+  <string name="calendar_event_added">Calendar event Added</string>
 
 </resources>

--- a/omniNotes/src/main/res/values/strings.xml
+++ b/omniNotes/src/main/res/values/strings.xml
@@ -229,6 +229,7 @@
   <string name="completed">Completed</string>
   <string name="undo_changes_note_confirmation">Confirm undoing changes?</string>
   <string name="done">Done</string>
+  <string name="sync_reminder">Sync reminder with Google Calendar</string>
 
   <!-- Settings -->
   <string name="dashclock_description">Displays some statistics and expiring reminders from Omni Notes</string>
@@ -434,5 +435,6 @@
   <string name="channel_reminders_description">Notifications for notes\' reminders</string>
   <string name="channel_pinned_name">Pinned</string>
   <string name="channel_pinned_description">Notifications for pinned notes</string>
+  <string name="remove_calendar_event">Remove calendar event?</string>
 
 </resources>


### PR DESCRIPTION
Hello, I created a simple button to sync a note with the calendar below the "Add reminder" button in the fragment_detail_content.xml.
The "Sync reminder with Calendar" button appears only when there's a reminder in the Note and as of now it only creates a new event with the start and end time being the reminder's time through the Calendar Intent. 
Is the button's placement okay below the reminder button or should I make the syncing an option in the options menu?
Also I could try to make a calendar helper script in order to be able to edit the existing events or delete them if the user decides to change or delete the reminder.