### PR TITLE
Add delombok step to code analysis action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,9 @@ jobs:
           # a pull request then we can checkout the head.
           fetch-depth: 2
 
+       - name: Delombok
+         uses: advanced-security/delombok@main
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
@@ -49,7 +52,7 @@ jobs:
         #    and modify them (or add more) to build your code if your project
         #    uses a compiled language
 
-        run: ./gradlew build
+        run: ./gradlew assembleDebug
 
 
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
I noticed that, after the recent addition of some Lombok code in this project, CodeQL no longer extracts the classes that use it. This PR adds a [delombok step](https://github.com/advanced-security/delombok/) to the code analysis GitHub Action so that those classes are extracted again, potentially uncovering new security issues.

⚠️ Take into account that **this is NOT an officially supported solution from GitHub**, but rather something that I recommend as an individual contributor. Take it with a grain of salt if you decide to use it 😄.

Also, I changed the build command to `assembleDebug`, which should be faster (both because it skips tests and only builds one flavor of the app) while being equally useful to CodeQL.