### PR TITLE
Fix Bug-Search Filter does not apply #981

### DIFF
--- a/omniNotes/src/main/java/it/feio/android/omninotes/ListFragment.java
+++ b/omniNotes/src/main/java/it/feio/android/omninotes/ListFragment.java
@@ -907,6 +907,7 @@ public class ListFragment extends BaseFragment implements OnViewTouchedListener,
   private void switchNotesView() {
     boolean expandedView = Prefs.getBoolean(PREF_EXPANDED_VIEW, true);
     Prefs.edit().putBoolean(PREF_EXPANDED_VIEW, !expandedView).apply();
+    searchQueryInstant = searchQuery;
     // Change list view
     initNotesList(mainActivity.getIntent());
     // Called to switch menu voices


### PR DESCRIPTION
Hello, I am honored to improve this popular and nice app. I fixed this bug #981. In ListFragment.java. The searchQueryInstant variable in searchQuery was not updated after changing the view size, resulting in the initNotesList function reloading search content with searchQueryInstant being empty. So I added `searchQueryInstant=searchQuery` to the switchNotesView function.

Please review the code I have modified and feel free to contact me if there are any issues.