### PR TITLE
fix for #990: runtime permission for alarm services in android 12+ devices

### DIFF
--- a/omniNotes/src/main/AndroidManifest.xml
+++ b/omniNotes/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
   <uses-permission android:name="com.pushbullet.android.permission.SEND_MESSAGES" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+  <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
   <uses-permission android:name="android.permission.CAMERA"/>
 


### PR DESCRIPTION
A runtime check for reminders are added fro android 12+ devices

<img width="325" alt="image" src="https://github.com/user-attachments/assets/4fedb885-caf7-436b-923c-8b9ff7ef053f">
